### PR TITLE
Fix startup crash on release builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,8 +113,7 @@ dependencies = [
 [[package]]
 name = "native-windows-gui"
 version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e049bccae62e28782c5eff82e0c8a4dace50b9783fe03b95447fef3172bb89"
+source = "git+https://github.com/nickbeth/native-windows-gui.git?branch=transmute-ub-1.0.12#088783c7c18fa1506484a38e3d7a489c48165007"
 dependencies = [
  "bitflags",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ windows-sys = { version = "0.52.0", features = [
     "Win32_UI_WindowsAndMessaging",
 ] }
 native-windows-derive = "1.0.5"
+
+# Version 1.0.13 of native-windows-gui breaks nested flex layouts, use 1.0.12 instead
 native-windows-gui = { version = "=1.0.12", default-features = false, features = [
     "cursor",
     "embed-resource",
@@ -37,6 +39,11 @@ native-windows-gui = { version = "=1.0.12", default-features = false, features =
 ] }
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.115"
+
+[patch.crates-io]
+# This is a temporary fix for a crash in the native-windows-gui crate
+# See https://github.com/gabdube/native-windows-gui/pull/308
+native-windows-gui = { git = "https://github.com/nickbeth/native-windows-gui.git", branch = "transmute-ub-1.0.12" }
 
 [build-dependencies]
 embed-resource = "2.4"


### PR DESCRIPTION
Closes #8.

This seems to be an issue only on recent Rust versions, at least `> 1.82.0`. The current latest release `v1.1.0` was compiled with a previous version that doesn't seem affected by this issue, so this PR doesn't warrant a new release.